### PR TITLE
Modified presentation picker to remove selected topics

### DIFF
--- a/src/main/java/babaksoft/PresentationController.java
+++ b/src/main/java/babaksoft/PresentationController.java
@@ -29,10 +29,16 @@ public class PresentationController {
         // heavily inelegant and inefficient code follows...
         // TODO replace with proper repository query instead
         List<ProjectGroup> decidedGroups = new ArrayList<>();
+        List<Presentation> availableTopics = new ArrayList<Presentation>();
 
         for (Presentation p: presentations) {
             ProjectGroup g = p.getProjectGroup();
-            if (g != null) decidedGroups.add(g);
+            if (g != null) {
+                decidedGroups.add(g);
+            } else  {
+                availableTopics.add(p);
+            }
+
         }
 
         List<ProjectGroup> allGroups = new ArrayList<>();
@@ -41,7 +47,7 @@ public class PresentationController {
 
         allGroups.removeAll(decidedGroups);
 
-        model.addAttribute("presentations", presentations);
+        model.addAttribute("presentations", availableTopics);
         model.addAttribute("groups", allGroups);
         return "hello";
     }

--- a/src/test/java/babaksoft/PresentationPickerMockMvcTests.java
+++ b/src/test/java/babaksoft/PresentationPickerMockMvcTests.java
@@ -35,16 +35,19 @@ public class PresentationPickerMockMvcTests {
         this.mockMvc.perform(get("/")).andDo(print()).andExpect(status().isOk())
                 .andExpect(content().string(containsString("fefe")));
     }
-
     @Test
     public void correctlyIncludesPresentationAndItsGroupAfterLocalInsertion() throws Exception {
-        Presentation pres = new Presentation("fefe");
-        ProjectGroup pg = new ProjectGroup("beuarh");
-        pres.setProjectGroup(pg);
-        repository.save(pres);
+        Presentation pres1 = new Presentation("fefe");
+        ProjectGroup pg1 = new ProjectGroup("beuarh");
+        Presentation pres2 = new Presentation("foo");
+
+
+        pres1.setProjectGroup(pg1);
+        repository.save(pres1);
+        repository.save(pres2);
 
         this.mockMvc.perform(get("/")).andDo(print()).andExpect(status().isOk())
-                .andExpect(content().string(containsString("fefe")))
-                .andExpect(content().string(containsString("beuarh")));
+                .andExpect(content().string(containsString("foo")))
+                .andExpect(content().string(not(containsString("fefe"))));
     }
 }


### PR DESCRIPTION
This new behaviour removes selected topics from the list once it is chosen. This makes it much simpler for students to know which topics are still available